### PR TITLE
Fix for VenueSearch

### DIFF
--- a/src/Core/FourSquareMultipleVenuesResponse.cs
+++ b/src/Core/FourSquareMultipleVenuesResponse.cs
@@ -1,0 +1,13 @@
+﻿using FourSquare.SharpSquare.Entities;
+
+namespace FourSquare.SharpSquare.Core
+{
+    public class FourSquareMultipleVenuesResponse<T> : FourSquareResponse where T : FourSquareEntity
+    {
+        public VenueResponse<T> response
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/src/Core/SharpSquare.cs
+++ b/src/Core/SharpSquare.cs
@@ -146,27 +146,7 @@ namespace FourSquare.SharpSquare.Core
             return fourSquareResponse;
         }
 
-
-        #region CustomCode
-
-        // Note: SearchVenues throws exception beacuse Foursquare response contains "List<Venue>" and "Geocode" but it is not handled in SharpSquare code.
-
-        private Task<FourSquareMultipleVenuesResponse<T>> GetMultipleVenues<T>(string endpoint) where T : FourSquareEntity
-        {
-            return GetMultipleVenues<T>(endpoint, null, false);
-        }
-
-        private Task<FourSquareMultipleVenuesResponse<T>> GetMultipleVenues<T>(string endpoint, bool unauthenticated) where T : FourSquareEntity
-        {
-            return GetMultipleVenues<T>(endpoint, null, unauthenticated);
-        }
-
-        private Task<FourSquareMultipleVenuesResponse<T>> GetMultipleVenues<T>(string endpoint, Dictionary<string, string> parameters) where T : FourSquareEntity
-        {
-            return GetMultipleVenues<T>(endpoint, parameters, false);
-        }
-
-        private async Task<FourSquareMultipleVenuesResponse<T>> GetMultipleVenues<T>(string endpoint, Dictionary<string, string> parameters, bool unauthenticated) where T : FourSquareEntity
+        private async Task<FourSquareMultipleVenuesResponse<T>> GetMultipleVenues<T>(string endpoint, Dictionary<string, string> parameters = null, bool unauthenticated = false) where T : FourSquareEntity
         {
             string serializedParameters = "";
             if (parameters != null)
@@ -188,8 +168,6 @@ namespace FourSquare.SharpSquare.Core
             var fourSquareResponse = JsonConvert.DeserializeObject<FourSquareMultipleVenuesResponse<T>>(json);
             return fourSquareResponse;
         }
-
-        #endregion
 
         private async Task Post(string endpoint, Dictionary<string, string> parameters = null)
         {

--- a/src/Core/VenueResponse.cs
+++ b/src/Core/VenueResponse.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+
+namespace FourSquare.SharpSquare.Core
+{
+    public class VenueResponse<T>
+    {
+        public Dictionary<string, object> geocoded
+        {
+            get;
+            set;
+        }
+        public List<T> venues
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/src/SharpSquare.csproj
+++ b/src/SharpSquare.csproj
@@ -41,10 +41,12 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Core\FourSquareMultipleResponse.cs" />
+    <Compile Include="Core\FourSquareMultipleVenuesResponse.cs" />
     <Compile Include="Core\FourSquareResponse.cs" />
     <Compile Include="Core\FourSquareSingleResponse.cs" />
     <Compile Include="Core\FourSquareSingleRootResponse.cs" />
     <Compile Include="Core\SharpSquare.cs" />
+    <Compile Include="Core\VenueResponse.cs" />
     <Compile Include="Entities\Badge.cs" />
     <Compile Include="Entities\Category.cs" />
     <Compile Include="Entities\Checkin.cs" />


### PR DESCRIPTION
I was playing around with the SharpSquare library in a Windows Phone project and discovered that the SearchVenues method was throwing an exception because the JSON was not what the code expected.

I noticed that the original SharpSquare repository has a fix for this, and so I've copied (and adjusted for async) the pertinent code so that SharpSquare PCL can also have this fix.

Here's the original fix:
https://github.com/TICLAB/SharpSquare/commit/6c10bc9bf71c07947818cc4ab5319c6eef91acf7?diff=unified